### PR TITLE
Adding error handling around fetch call.

### DIFF
--- a/install.cjs
+++ b/install.cjs
@@ -8,8 +8,12 @@ const assert = require('assert');
 const GITHUB_REPO = 'https://github.com/FedericoCarboni/node-ntsuspend';
 
 const fetch = (input) => {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     https.request(input, (res) => {
+      if(res.statusCode >= 400) {
+        reject(`${res.statusCode}: ${res.statusMessage}`);
+      }
+
       if (res.statusCode === 302) {
         resolve(fetch(res.headers.location));
       } else {
@@ -22,8 +26,8 @@ const fetch = (input) => {
 const install = async () => {
   const filename = `win32-${process.arch}_lib.node`;
   const download = `${GITHUB_REPO}/releases/download/v${pkg.version}/${filename}`;
+
   const dest = path.join(__dirname, filename);
-  const response = await fetch(download);
   const stream = fs.createWriteStream(dest);
   stream.once('close', () => {
     const ntsuspend = require('./lib.cjs');
@@ -31,7 +35,14 @@ const install = async () => {
     assert.strictEqual(typeof ntsuspend.resume, 'function');
     console.log(`Success: '${dest}' installed from remote '${download}'`);
   });
-  response.pipe(stream);
+
+  try {
+    const response = await fetch(download);
+    response.pipe(stream);
+  } catch (error) {
+    console.error(error);
+    throw new Error(error);
+  }
 };
 
 const { platform, arch, env: { SKIP_NTSUSPEND_BINARY } } = process;


### PR DESCRIPTION
This addition allows other scripts to call install if need be and handle the outcome correctly when the process closes with a code of 0 (successful) or 1 (failure).